### PR TITLE
feat(add): Support adding multiple commands at once

### DIFF
--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -88,6 +88,43 @@ func (s *Storage) Add(text string) error {
 	return s.Save(commands)
 }
 
+// AddBulk appends multiple new commands to storage
+func (s *Storage) AddBulk(texts []string) (int, error) {
+	commands, err := s.Load()
+	if err != nil {
+		return 0, err
+	}
+
+	existing := make(map[string]bool)
+	for _, cmd := range commands {
+		existing[cmd.Text] = true
+	}
+
+	var newCommands []Command
+	for _, text := range texts {
+		if _, found := existing[text]; !found {
+			newCommands = append(newCommands, Command{
+				Text:      text,
+				CreatedAt: time.Now(),
+				UseCount:  0,
+			})
+			existing[text] = true // Mark as seen for future checks within the same bulk add
+		}
+	}
+
+	if len(newCommands) == 0 {
+		return 0, nil
+	}
+
+	allCommands := append(commands, newCommands...)
+
+	if err := s.Save(allCommands); err != nil {
+		return 0, err
+	}
+
+	return len(newCommands), nil
+}
+
 // Remove deletes a command from storage
 func (s *Storage) Remove(text string) error {
 	commands, err := s.Load()

--- a/internal/storage/storage_bulk_test.go
+++ b/internal/storage/storage_bulk_test.go
@@ -1,0 +1,87 @@
+package storage
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAddBulk(t *testing.T) {
+	// Create a temporary directory for testing
+	tmpDir, err := os.MkdirTemp("", "stash-test-bulk")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Create storage with custom path
+	store := &Storage{
+		path: filepath.Join(tmpDir, "commands.json"),
+	}
+
+	// Initial commands
+	initialCmds := []string{"echo 'first'", "ls -l"}
+	numAdded, err := store.AddBulk(initialCmds)
+	if err != nil {
+		t.Fatalf("Initial AddBulk() error = %v", err)
+	}
+	if numAdded != 2 {
+		t.Fatalf("Initial AddBulk() numAdded = %d, want 2", numAdded)
+	}
+
+	// Test AddBulk with new and duplicate commands
+	t.Run("AddBulk_NewAndDuplicates", func(t *testing.T) {
+		bulkCmds := []string{"git status", "ls -l", "echo 'another'", "git status"}
+		numAdded, err := store.AddBulk(bulkCmds)
+		if err != nil {
+			t.Errorf("AddBulk() error = %v", err)
+		}
+		if numAdded != 2 {
+			t.Errorf("AddBulk() numAdded = %d, want 2", numAdded)
+		}
+
+		commands, err := store.Load()
+		if err != nil {
+			t.Errorf("Load() error = %v", err)
+		}
+
+		// Expect 4 unique commands
+		if len(commands) != 4 {
+			t.Errorf("Load() len = %d, want 4", len(commands))
+		}
+
+		// Check for specific commands
+		expectedTexts := map[string]bool{
+			"echo 'first'":   true,
+			"ls -l":          true,
+			"git status":     true,
+			"echo 'another'": true,
+		}
+
+		for _, cmd := range commands {
+			if !expectedTexts[cmd.Text] {
+				t.Errorf("Unexpected command found: %q", cmd.Text)
+			}
+		}
+	})
+
+	// Test AddBulk with only existing commands
+	t.Run("AddBulk_OnlyExisting", func(t *testing.T) {
+		bulkCmds := []string{"ls -l", "echo 'first'"}
+		numAdded, err := store.AddBulk(bulkCmds)
+		if err != nil {
+			t.Errorf("AddBulk() error = %v", err)
+		}
+		if numAdded != 0 {
+			t.Errorf("AddBulk() numAdded = %d, want 0", numAdded)
+		}
+
+		commands, err := store.Load()
+		if err != nil {
+			t.Errorf("Load() error = %v", err)
+		}
+		if len(commands) != 4 {
+			t.Errorf("Load() len after adding only existing = %d, want 4", len(commands))
+		}
+	})
+}

--- a/main.go
+++ b/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/atotto/clipboard"
 	tea "github.com/charmbracelet/bubbletea"
@@ -38,9 +40,19 @@ var listCmd = &cobra.Command{
 	},
 }
 
+var addCmd = &cobra.Command{
+	Use:   "add [command1] [command2] ... [flags]",
+	Short: "Add one or more commands to the stash",
+	Run:   runAdd,
+}
+
 func init() {
 	rootCmd.AddCommand(popCmd)
 	rootCmd.AddCommand(listCmd)
+	rootCmd.AddCommand(addCmd)
+
+	addCmd.Flags().String("bulk", "", "Comma-separated commands to add")
+	addCmd.Flags().String("file", "", "Path to a file containing commands (one per line)")
 
 	rootCmd.CompletionOptions.DisableDefaultCmd = true
 }
@@ -109,4 +121,70 @@ func runList() {
 	for i, cmd := range commands {
 		fmt.Printf("%d. %s\n", i+1, cmd)
 	}
+}
+
+func runAdd(cmd *cobra.Command, args []string) {
+	bulkString, _ := cmd.Flags().GetString("bulk")
+	file, _ := cmd.Flags().GetString("file")
+
+	var commands []string
+	if bulkString != "" {
+		// Split the bulk string by comma and trim spaces
+		for _, c := range strings.Split(bulkString, ",") {
+			trimmedCmd := strings.TrimSpace(c)
+			if trimmedCmd != "" {
+				commands = append(commands, trimmedCmd)
+			}
+		}
+	}
+
+	if file != "" {
+		fileCommands, err := readCommandsFromFile(file)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error reading commands from file: %v\n", err)
+			os.Exit(1)
+		}
+		commands = append(commands, fileCommands...)
+	}
+
+	// Add commands from args
+	commands = append(commands, args...)
+
+	if len(commands) == 0 {
+		fmt.Println("No commands to add. Use --bulk, --file flag or add commands as arguments.")
+		return
+	}
+
+	store, err := storage.New()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error initializing storage: %v\n", err)
+		os.Exit(1)
+	}
+	if numAdded, err := store.AddBulk(commands); err != nil {
+		fmt.Fprintf(os.Stderr, "Error adding commands: %v\n", err)
+		os.Exit(1)
+	} else if numAdded > 0 {
+		fmt.Printf("Added %d new commands.\n", numAdded)
+	} else {
+		fmt.Println("No new commands to add.")
+	}
+}
+
+func readCommandsFromFile(filePath string) ([]string, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	var commands []string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line != "" {
+			commands = append(commands, line)
+		}
+	}
+
+	return commands, scanner.Err()
 }


### PR DESCRIPTION
## Description

This pull request enhances the `add` command to support adding multiple commands at once, providing a more efficient and user-friendly experience. Users can now add commands directly as arguments, from a comma-separated string, or from a file.

## Motivation

The previous implementation of the `add` command only allowed adding commands one by one, which could be cumbersome when a user wants to add multiple commands. This change streamlines the process of adding commands to the stash, making it more convenient for users to manage their command history.

## Implementation

The following changes have been made to implement this feature:

-   **`main.go`:**
    -   The `addCmd` `Use` string has been updated to reflect the new functionality.
    -   The `runAdd` function has been modified to process commands from a comma-separated string (`--bulk`), a file (`--file`), and now also from command-line arguments.
-   **`internal/storage/storage.go`:**
    -   A new `AddBulk` function has been added to handle the addition of multiple commands to the storage. This function ensures that duplicate commands are not added.
-   **`internal/storage/storage_bulk_test.go`:**
    -   A new test file has been added to test the `AddBulk` function, ensuring its correctness and reliability.

## How to Use

### Add commands as arguments

```bash
cli-stash add "echo 'hello world'" "ls -la"


Add commands from a comma-separated string

```bash
cli-stash add --bulk "git status, docker ps, kubectl get pods"
```

### Add commands from a file

```bash
cli-stash add --file commands.txt
```
This change improves the usability of `cli-stash` and makes it a more powerful tool for managing shell commands.